### PR TITLE
Implement keybinding to sync whole project

### DIFF
--- a/keymaps/atom-sync.cson
+++ b/keymaps/atom-sync.cson
@@ -12,3 +12,4 @@
 
 'atom-workspace':
     'ctrl-alt-l': 'atom-sync:toggle-log-panel'
+    'ctrl-shift-a': 'atom-sync:upload-project'

--- a/lib/atom-sync.coffee
+++ b/lib/atom-sync.coffee
@@ -15,6 +15,9 @@ module.exports = AtomSync =
         @subscriptions.add atom.commands.add 'atom-workspace', 'atom-sync:test': (e) =>
             @controller.test "test", @getSelectedPath e.target
 
+        @subscriptions.add atom.commands.add 'atom-workspace', 'atom-sync:upload-project': (e) =>
+            @controller.onSync (atom.project.getPaths()[0]), 'up'
+
         @subscriptions.add atom.commands.add 'atom-workspace', 'atom-sync:download-directory': (e) =>
             @controller.onSync (@getSelectedPath e.target), 'down'
 


### PR DESCRIPTION
By pressing `Ctrl+Shift+a` the whole project folder will be synced.

FIXME: Suggestions on how users can choose what project root to use?

Implements #27  