### PR TITLE
Run rsync with project as working directory

### DIFF
--- a/lib/service/rsync-service.coffee
+++ b/lib/service/rsync-service.coffee
@@ -32,6 +32,8 @@ module.exports = (opt = {}) ->
   progress = opt.progress
   shell = config.option?.shell ? 'ssh'
 
+  [projectDirectory] = atom.project.relativizePath(src)
+
   rsync = new Rsync()
     .shell shell
     .flags flags
@@ -40,6 +42,7 @@ module.exports = (opt = {}) ->
     .output (data) ->
       progress? data.toString('utf-8').trim()
 
+  rsync.cwd(projectDirectory)
   rsync.delete() if config.option?.deleteFiles
   rsync.exclude config.option.exclude if config.option?.exclude
   rsync.execute (err, code, cmd) =>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^4.11.1",
     "node-sshclient": "^0.2.0",
     "property-accessors": "^1.1.3",
-    "rsync": "^0.4.0",
+    "rsync": "^0.5.0",
     "season": "^5.3.0"
   }
 }


### PR DESCRIPTION
When you start to follow the idea proposed in https://github.com/dingjie/atom-sync/pull/38 and try to use `shell` parameter to set path to identity file, there is no way to set it relative to the project directory.

This PR makes rsync execute with project directory as cwd so every relative path is now resolved against it. You can still use absolute paths or `~` shortcut.
