### PR TITLE
Patch 1

### DIFF
--- a/lib/controller/service-controller.coffee
+++ b/lib/controller/service-controller.coffee
@@ -27,12 +27,12 @@ module.exports = ServiceController =
     @config.initialise obj
 
   onSave: (obj) ->
-    config = @config.load obj
-    @onSync obj, 'up' if config?.behaviour?.uploadOnSave
+    config = @config.loadReal obj
+    @onSync config.filename, 'up' if config?.behaviour?.uploadOnSave
 
   onOpen: (obj) ->
-    config = @config.load obj
-    @onSync obj, 'down' if config?.behaviour?.syncDownOnOpen
+    config = @config.loadReal obj
+    @onSync config.filename, 'down' if config?.behaviour?.syncDownOnOpen
 
   onSync: (obj, direction) ->
     obj = path.normalize obj

--- a/lib/helper/config-helper.coffee
+++ b/lib/helper/config-helper.coffee
@@ -18,6 +18,18 @@ module.exports = ConfigHelper =
     return if not config or not fs.isFileSync config
     cson.readFileSync config
 
+  loadReal: (f) ->
+    config = @load f
+    if config
+      config.filename = f
+    else
+      for fRealPath in atom.project.getPaths() 
+        if (f.indexOf fRealPath) is -1
+          config = cson.readFileSync fRealPath + '/' + @configFileName
+          if config and (f.indexOf config?.option?.localRoot) isnt -1
+            config.filename = fRealPath + f.substr config.option.localRoot.length
+    config
+
   assert: (f) ->
     config = @load f
     if not config then throw new Error "You must create remote config first"

--- a/lib/helper/config-helper.coffee
+++ b/lib/helper/config-helper.coffee
@@ -64,6 +64,7 @@ module.exports = ConfigHelper =
       alwaysSyncAll: false
     option:
       deleteFiles: false
+      localRoot: false
       exclude: [
         '.sync-config.cson'
         '.git'


### PR DESCRIPTION
Added option to check correct project path for files when use symlink (mklink) on Windows.
For this, a new config method added: loadReal, which try to determine the correct project root path with localRoot configure options.
To use it just set "config.option.localRoot" at the config file.