### PR TITLE
Patch for Windows 10 + cygwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ atom-sync is an Atom package to sync files bidirectionally between remote host a
 * Ensure you have `ssh` and `rsync` installed.
 
 * Special on Windows
- * Install Cygwin from https://cygwin.org
- * Select "openssh" and "rsync" from packages and install them
- * rsync is not awailable in the cygwin-shell, but ...
- * add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
+  * Install Cygwin from https://cygwin.org
+  * Select "openssh" and "rsync" from packages and install them
+  * rsync is not awailable in the cygwin-shell, but ...
+  * add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
 
 * Add Path to Cygwin-Bin in windows 10
- * right-click on "start-menu" choose "System"
- * choose "advanced settings"
- * change "environment variables"
- * in the lower path select "PATH"
- * click "New"
- * Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
- * close dialogs
- * now atom should be able to use ssh + rsync
- * to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
- * in cygwin you can open "cygwin terminal" and check by "ls .ssh"
- * maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
+  * right-click on "start-menu" choose "System"
+  * choose "advanced settings"
+  * change "environment variables"
+  * in the lower path select "PATH"
+  * click "New"
+  * Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
+  * close dialogs
+  * now atom should be able to use ssh + rsync
+  * to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
+  * in cygwin you can open "cygwin terminal" and check by "ls .ssh"
+  * maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
 
 
 ### Quick Start ###

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ atom-sync is an Atom package to sync files bidirectionally between remote host a
 * Ensure you have `ssh` and `rsync` installed.
 
 * Special on Windows
-** Install Cygwin from https://cygwin.org
-** Select "openssh" and "rsync" from packages and install them
-** rsync is not awailable in the cygwin-shell, but ...
-** add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
+ * Install Cygwin from https://cygwin.org
+ * Select "openssh" and "rsync" from packages and install them
+ * rsync is not awailable in the cygwin-shell, but ...
+ * add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
 
 * Add Path to Cygwin-Bin in windows 10
-** right-click on "start-menu" choose "System"
-** choose "advanced settings"
-** change "environment variables"
-** in the lower path select "PATH"
-** click "New"
-** Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
-** close dialogs
-** now atom should be able to use ssh + rsync
-** to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
-** in cygwin you can open "cygwin terminal" and check by "ls .ssh"
-** maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
+ * right-click on "start-menu" choose "System"
+ * choose "advanced settings"
+ * change "environment variables"
+ * in the lower path select "PATH"
+ * click "New"
+ * Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
+ * close dialogs
+ * now atom should be able to use ssh + rsync
+ * to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
+ * in cygwin you can open "cygwin terminal" and check by "ls .ssh"
+ * maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
 
 
 ### Quick Start ###

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ atom-sync is an Atom package to sync files bidirectionally between remote host a
 * Special on Windows
   * Install Cygwin from https://cygwin.org
   * Select "openssh" and "rsync" from packages and install them
-  * rsync is not awailable in the cygwin-shell, but ...
+  * rsync is now available in the cygwin-terminal, but not visible from atom
   * add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
 
-* Add Path to Cygwin-Bin in windows 10
+* Add Path to cygwin/bin in windows 10
   * right-click on "start-menu" choose "System"
   * choose "advanced settings"
   * change "environment variables"
@@ -30,7 +30,8 @@ atom-sync is an Atom package to sync files bidirectionally between remote host a
   * click "New"
   * Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
   * close dialogs
-  * now atom should be able to use ssh + rsync
+  
+* now atom should be able to use ssh + rsync
   * to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
   * in cygwin you can open "cygwin terminal" and check by "ls .ssh"
   * maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ atom-sync is an Atom package to sync files bidirectionally between remote host a
 ### Prerequisite ###
 * Ensure you have `ssh` and `rsync` installed.
 
+* Special on Windows
+** Install Cygwin from https://cygwin.org
+** Select "openssh" and "rsync" from packages and install them
+** rsync is not awailable in the cygwin-shell, but ...
+** add the cygwin/bin folder to %PATH% so that rsync is globally in cmd.exe
+
+* Add Path to Cygwin-Bin in windows 10
+** right-click on "start-menu" choose "System"
+** choose "advanced settings"
+** change "environment variables"
+** in the lower path select "PATH"
+** click "New"
+** Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
+** close dialogs
+** now atom should be able to use ssh + rsync
+** to proberly use ssh without password with autorized_keys, you need to have .ssh folder etc. 
+** in cygwin you can open "cygwin terminal" and check by "ls .ssh"
+** maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
+
+
 ### Quick Start ###
 * Open a project folder to sync in [Atom](http://atom.io).
 * Right click on the project folder and select `Sync` -> `Edit Remote Config`.

--- a/lib/controller/service-controller.coffee
+++ b/lib/controller/service-controller.coffee
@@ -81,7 +81,9 @@ module.exports = ServiceController =
 
   # Core
   genRemoteString: (user, remoteAddr, remotePath) ->
-    result = "#{remoteAddr}:#{remotePath}"
+    remotePathUnix = remotePath.replace("\\","/")
+    # fix Backslash to Slash on Windows
+    result = "#{remoteAddr}:#{remotePathUnix}"
     result = "#{user}@#{result}" if user
 
   sync: (src, dst, config = {}, provider, complete) ->

--- a/lib/controller/service-controller.coffee
+++ b/lib/controller/service-controller.coffee
@@ -81,16 +81,19 @@ module.exports = ServiceController =
 
   # Core
   genRemoteString: (user, remoteAddr, remotePath) ->
-    remotePathUnix = remotePath.replace("\\","/")
-    # fix Backslash to Slash on Windows
-    result = "#{remoteAddr}:#{remotePathUnix}"
+    result = "#{remoteAddr}:#{remotePath}"
     result = "#{user}@#{result}" if user
 
   sync: (src, dst, config = {}, provider, complete) ->
     delay = config.option?.autoHideDelay or 1500
 
+    # Fix Unix Path Delimiters
+    src = src.replace /\\/g, "/"
+    src = src.replace /^([A-Z])\:/ , "/cygdrive/$1"
+    dst = dst.replace /\\/g, "/"
+    dst = dst.replace /^([A-Z])\:/ , "/cygdrive/$1"
     @console.show() if not config.behaviour.forgetConsole
-    @console.info "=> Syncing from #{src} to #{dst} ..."
+    @console.info "=> Syncing from #{src} to #{dst} "
 
     (require '../service/' + provider)
       src: src,

--- a/menus/atom-sync.cson
+++ b/menus/atom-sync.cson
@@ -1,6 +1,6 @@
 # See https://atom.io/docs/latest/hacking-atom-package-word-count#menus for more details
 'context-menu':
-  '.tree-view.full-menu .header.list-item': [
+  '.tree-view .header.list-item': [
     'label': 'Sync'
     'submenu': [
       {
@@ -18,7 +18,7 @@
     ]
   ]
 
-  '.tree-view.full-menu .file.list-item': [
+  '.tree-view .file.list-item': [
     'label': 'Sync'
     'submenu': [
       {


### PR DESCRIPTION
With this Path-Patch for src and dst, now it also works under windows 10 in combination with using cygwin for rsync + ssh. 
see readme.md for documentation how to use it. 

i also tried on mac and there are no interferences of the patch. 

Drive "C:\" is detected and converted to /cygdrive/c/. 
with pattern matching for drive A: to Z:

i also applied the css-patch for the menu, so that the sync-menu shows up in atom 1.7